### PR TITLE
Fixing description of the "Deferencing pointers" challenge in the Memory module

### DIFF
--- a/memory/mem-dereference/DESCRIPTION.md
+++ b/memory/mem-dereference/DESCRIPTION.md
@@ -16,7 +16,7 @@ Let's start with this memory configuration:
 And consider this assembly snippet:
 
 ```assembly
-mov rdi, 133700
+mov rax, 133700
 ```
 
 Now, what you have is the following situation:
@@ -29,11 +29,11 @@ Now, what you have is the following situation:
                        │
  Register │ Contents   │
 +────────────────────+ │
-│ rdi     │ 133700   │─┘
+│ rax     │ 133700   │─┘
 +────────────────────+
 ```
 
-`rdi` now holds a value that corresponds with the address of the data that want to load!
+`rax` now holds a value that corresponds with the address of the data that want to load!
 Let's load it:
 
 ```assembly


### PR DESCRIPTION
The challenge uses the memory address stored in `rax` to explain deferencing, but it seems the first `mov` instruction is wrongly about putting this memory address in `rdi`, instead of `rax`. 