### PR TITLE
Fix in description to assembly-crash-course level 23

### DIFF
--- a/assembly-crash-course/level-23/DESCRIPTION.md
+++ b/assembly-crash-course/level-23/DESCRIPTION.md
@@ -20,7 +20,7 @@ mov rbp, rsp
 sub rsp, 0x14
 ; assign list[2] = 1337
 mov eax, 1337
-mov [rbp-0x8], eax
+mov [rbp-0xc], eax
 ; do more operations on the list ...
 ; restore the allocated space
 mov rsp, rbp
@@ -28,6 +28,8 @@ ret
 ```
 
 Notice how `rbp` is always used to restore the stack to where it originally was. If we don't restore the stack after use, we will eventually run out. In addition, notice how we subtracted from `rsp`, because the stack grows down. To make the stack have more space, we subtract the space we need. The `ret` and `call` still work the same.
+
+Consider the fact that to assign a value to `list[2]` we subtract 12 bytes (3 dwords). That is because stack grows down and when we moved `rsp` our stack contains addresses <`rsp`, `rbp`).
 
 Once again, please make function(s) that implement the following:
 


### PR DESCRIPTION
Saying that code below is equal to `list[2] = 1337`
```assembly
mov eax, 1337
mov [rbp-0x8], eax
```
can be understood that `list[0] = 1337`
```assembly
mov eax, 1337
mov [rbp], eax
```
and that would attempt to write to memory outside of stack. Most languages use 0-based indexing so I think that the fix is in place. The additional note is just my proposal but I can remove it if in your opinion it is poorly written or redundant.