### PR TITLE
Fixed typo for moving data between registers

### DIFF
--- a/your-first-program/movreg/DESCRIPTION.md
+++ b/your-first-program/movreg/DESCRIPTION.md
@@ -14,7 +14,7 @@ mov rsi, 42
 mov rdi, rsi
 ```
 
-Just like the first line there moves `42` into `rsi`, the second like moves the value in `rsi` to `rdi`.
+Just like the first line there moves `42` into `rsi`, the second line moves the value in `rsi` to `rdi`.
 Here, we have to mention one complication: by _move_, we really mean _set_.
 After the snippet above, `rsi` _and_ `rdi` will be `42`.
 It's a mystery as to why the `mov` was chosen rather than something reasonable like `set` (even very knowledgeable people resort to [wild speculation](https://retrocomputing.stackexchange.com/questions/12968/why-is-the-processor-instruction-called-move-not-copy) when asked), but it was, and here we are.


### PR DESCRIPTION
Fixed minor typo error on this dojo as I spotted it during the challenge.