### PR TITLE
Change rax to al 

### DIFF
--- a/memory/mem-offsets/.py/chalconf.py
+++ b/memory/mem-offsets/.py/chalconf.py
@@ -4,5 +4,5 @@ addr_chain = [ random.randrange(0x1337000, 0x1338000), ]
 secret_addr_reg = 'rdi'
 value_offset = 8
 num_instructions = 3
-must_set_regs = [ "rax", "rdi" ]
+must_set_regs = [ "al", "rdi" ]
 final_reg_vals = { "rax": 60 }

--- a/memory/mem-offsets/DESCRIPTION.md
+++ b/memory/mem-offsets/DESCRIPTION.md
@@ -25,12 +25,12 @@ For example, if your pointer (say, `rdi`) points to a sequence of numbers in mem
 If you want the second number of that sequence, you could do:
 
 ```assembly
-mov rax, [rdi+1]
+mov al, [rdi+1]
 ```
 
 Wow, super simple!
 In memory terms, we call these number slots _bytes_: each memory address represents a specific byte of memory.
-The above example is accessing memory 1 byte after the memory address pointed to by `rax`.
+The above example is accessing memory 1 byte after the memory address pointed to by `al`.
 In memory terms, we call this 1 byte difference an _offset_, so in this example, there is an offset of 1 from the address pointed to by `rdi`.
 
 Let's practice this concept.


### PR DESCRIPTION
Change from `rax` to `al` in problem description and solution checker, to reflect the intention of moving one byte, not eight.