### PR TITLE
Revert previous erroneous commit

### DIFF
--- a/assembly-crash-course/level-8/DESCRIPTION.md
+++ b/assembly-crash-course/level-8/DESCRIPTION.md
@@ -59,4 +59,3 @@ Here are some truth tables for reference:
 Without using the following instructions: `mov`, `xchg`, please perform the following:
 
 Set `rax` to the value of `(rdi AND rsi)`
-**Tip:** You can assume that `rax` is initially filled with zeros.


### PR DESCRIPTION
The tip that was added in the last commit appears to be erroneous and misleading, according to Discord comments. Therefore removing this line again.