### PR TITLE
Progression lock level 7 and 8 of gdb module

### DIFF
--- a/debugging-refresher/module.yml
+++ b/debugging-refresher/module.yml
@@ -14,8 +14,10 @@ challenges:
   name: level6
 - id: level-7
   name: level7
+  progression_locked: true
 - id: level-8
   name: level8
+  progression_locked: true
 resources:
 - name: Robert's GDB Walkthrough
   type: lecture


### PR DESCRIPTION
This PR adds the progression_locked flag set to true for levels 7 and 8 of debugging refresher.