### PR TITLE
Align description with run description

### DIFF
--- a/assembly-crash-course/level-23/DESCRIPTION.md
+++ b/assembly-crash-course/level-23/DESCRIPTION.md
@@ -44,7 +44,7 @@ most_common_byte(src_addr, size):
   b = 0
   max_freq = 0
   max_freq_byte = 0
-  while b <= 0x100:
+  while b <= 0xff:
     if [stack_base - b * 2] > max_freq:
       max_freq = [stack_base - b * 2]
       max_freq_byte = b


### PR DESCRIPTION
Comparing against ASMLevel30 and level-23/DESCRIPTION.md reveals 
(red is the class in run, green is the description)

```patch
most_common_byte(src_addr, size):
  i = 0
  while i <= size-1:
    curr_byte = [src_addr + i]
    [stack_base - curr_byte * 2] += 1
    i += 1

-   b = 0
+  b = 1
  max_freq = 0
  max_freq_byte = 0
-  while b <= 0xff:
+  while b <= 0x100
    if [stack_base - b * 2] > max_freq:
      max_freq = [stack_base - b * 2]
      max_freq_byte = b
    b += 1

  return max_freq_byte
```

Maybe it's worth adding a warning/note and/or renaming "stack_base" to "list_base", because when doing this my dumbass forgot about the fact that rsp contains the return pointer, since the function is `call`ed; or maybe I'm just a dumbass that forgot