### PR TITLE
Specify read syscall code in "Reading Data" challenge description

### DIFF
--- a/hello-hackers/read/DESCRIPTION.md
+++ b/hello-hackers/read/DESCRIPTION.md
@@ -2,7 +2,7 @@ You now know how to output data to stdout using `write`.
 But how does your program receive input data?
 It `read`s it from stdin!
 
-Like `write`, `read` is a system call that shunts data around between file descriptors and memory.
+Like `write`, `read` is a system call that shunts data around between file descriptors and memory, and its syscall number is `0`.
 In `read`'s case, it reads some amount of bytes from the provided file descriptor and stores them in memory.
 The C-style syntax is the same as `write`:
 


### PR DESCRIPTION
The syscall code for `read` was not specified in challenge description as in the "Writing Output" challenge, thus it may create some confusion for those who don't know the syscall codes.