### PR TITLE
Update DESCRIPTION.md

### DIFF
--- a/assembly-crash-course/level-18/DESCRIPTION.md
+++ b/assembly-crash-course/level-18/DESCRIPTION.md
@@ -52,7 +52,7 @@ else:
 ```
 
 Where:
-- `x = rdi`, `y = rax`.
+- `x = edi`, `y = eax`.
 
 Assume each dereferenced value is a signed dword. This means the values can start as a negative value at each memory position.
 


### PR DESCRIPTION
"Assume each dereferenced value is a signed dword"

specifying eax and edi (instead of rax and rdi) will remove confusion as the values set in the challenge are definitely 4 bytes long ( a double word)