### PR TITLE
Updated asm level 2a description from rdi to rax

### DIFF
--- a/assembly-crash-course/level-2-a/DESCRIPTION.md
+++ b/assembly-crash-course/level-2-a/DESCRIPTION.md
@@ -2,6 +2,6 @@ In this level, you will be working with registers. You will be asked to modify o
 
 In this level, you will work with multiple registers. Please set the following:
 
-- `rdi = 0x1337`
+- `rax = 0x1337`
 - `r12 = 0xCAFED00D1337BEEF`
 - `rsp = 0x31337`


### PR DESCRIPTION
This seems to be a typo since in the `run` file when `config = 2` it would use this https://github.com/pwncollege/computing-101/blob/main/assembly-crash-course/run#L494 where `rax` is being set instead of `rdi`.