### PR TITLE
Updated asm 17a description

### DIFF
--- a/assembly-crash-course/level-17-a/DESCRIPTION.md
+++ b/assembly-crash-course/level-17-a/DESCRIPTION.md
@@ -23,6 +23,6 @@ For all jumps, there are three types:
 - Absolute jumps: jump to a specific address.
 - Indirect jumps: jump to the memory address specified in a register.
 
-In x86, absolute jumps (jump to a specific address) are accomplished by first putting the target address in a register `reg`, then doing `jmp reg`.
+In x86, absolute jumps (jump to a specific address) are accomplished by first loading the target address into a general-purpose register (we'll call this placeholder `reg`), then doing `jmp reg`.
 
 In this level, we will ask you to do an absolute jump. Perform the following: Jump to the absolute address `0x403000`.


### PR DESCRIPTION
Someone on discord suggested that the [`reg`](https://github.com/pwncollege/computing-101/blob/main/assembly-crash-course/level-17-a/DESCRIPTION.md?plain=1#L26) part in the `DESCRIPTION.md` was ambiguous so this change helps in making it clear that `reg` is a placeholder and not a register in itself. Seemed like something that should be obvious but still proposing changes. If the implication of `reg` being a placeholder is already clear then disregard this request.