### PR TITLE
Update Assembly crash course level 8 description

### DIFF
--- a/assembly-crash-course/level-8/DESCRIPTION.md
+++ b/assembly-crash-course/level-8/DESCRIPTION.md
@@ -62,4 +62,7 @@ Please perform the following:
 
 Set `rax` to the value of `(rdi AND rsi)`
 
-Note: `rax` will have all bits set to `1`
+----
+**NOTE:**
+`rax` will have all bits set to `1`
+If it didn't, this level would be trickier!


### PR DESCRIPTION
add a small note to the bottom of the description to tell users that `rax` has all bits set to `1`