### PR TITLE
Fix typo in description: update x, y registers to rdi, rax

### DIFF
--- a/assembly-crash-course/level-18/DESCRIPTION.md
+++ b/assembly-crash-course/level-18/DESCRIPTION.md
@@ -52,7 +52,7 @@ else:
 ```
 
 Where:
-- `x = edi`, `y = eax`.
+- `x = rdi`, `y = rax`.
 
 Assume each dereferenced value is a signed dword. This means the values can start as a negative value at each memory position.
 


### PR DESCRIPTION
Update the problem description to match the grading tool, which is `ASMLevel25` in `/challenege/run`.

```
Using the above knowledge, implement the following:
  if [x] is 0x7f454c46:
    y = [x+4] + [x+8] + [x+12]
  else if [x] is 0x00005A4D:
    y = [x+4] - [x+8] - [x+12]
  else:
    y = [x+4] * [x+8] * [x+12]

where:
<<<<<<< ASMLevel25
  x = rdi, y = rax.
=======
  x = edi, y = eax.
>>>>>>> DESCRIPTION.md

Assume each dereferenced value is a signed dword.
```

It has been updated to reflect the 64-bit environment and ensure consistency with the actual execution.

Note: It doesn't matter while solving the problem and still works correctly and produces the same results, but for consistency. :D
