### PR TITLE
Update link to pwndbg features list

### DIFF
--- a/debugging-refresher/module.yml
+++ b/debugging-refresher/module.yml
@@ -31,6 +31,6 @@ resources:
     - [GDB's documentation](https://sourceware.org/gdb/onlinedocs/gdb/index.html)
     - [Tudor's gdb crash course](https://web.archive.org/web/20250101052732/https://users.umiacs.umd.edu/~tdumitra/courses/ENEE757/Fall15/misc/gdb_tutorial.html)
     - [gdb debugging full example](https://www.brendangregg.com/blog/2016-08-09/gdb-example-ncurses.html)
-    - [pwndbg: a gdb extension (feature list)](https://pwndbg.re/pwndbg/latest/features/)
+    - [pwndbg: a gdb extension (feature list)](https://pwndbg.re/stable/features/)
     - [gef: another gdb extension (feature list)](https://hugsy.github.io/gef/commands/aliases/)
     - The course [Debuggers 1012: Introductory GDB](https://ost2.fyi/Dbg1012) from OpenSecurityTraining2.


### PR DESCRIPTION
The previous link leads to a 404 error.

This pull request updates the GDB Help section with a current link to the features page for pwndgb.

https://pwndbg.re/stable/features/

Fixes: #52