### PR TITLE
Update DESCRIPTION.md

### DIFF
--- a/assembly-crash-course/level-7/DESCRIPTION.md
+++ b/assembly-crash-course/level-7/DESCRIPTION.md
@@ -13,7 +13,7 @@ Take, for instance, `al`, the lowest 8 (or _least significant_ 8) bits of `rax`.
 The value in `al` (in bits) is:
 
 ```
-rax = 10001010
+al = 10001010
 ```
 
 If we shift once to the left using the `shl` instruction:


### PR DESCRIPTION
Change from `rax` to `al` in example as this part was talking about `al` specifically (just to avoid confusion), also the next example uses `al` instead.